### PR TITLE
Hybrid and NonInout implementations

### DIFF
--- a/Sources/request_types.swift
+++ b/Sources/request_types.swift
@@ -83,3 +83,81 @@ final class ReferenceResponse {
         self.status = status
     }
 }
+
+
+
+struct HybridRequest {
+  private final class Impl {
+    var method: Method
+    var path: String
+    var headers: [String: String]
+    var body: Bytes
+
+    init(_ method: Method, path: String, headers: [String: String], body: Bytes) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+    
+    convenience init(copying original: Impl) {
+      self.init(original.method, path: original.path, headers: original.headers, body: original.body)
+    }
+  }
+  
+  private var impl: Impl
+  private var implForMutation: Impl {
+    mutating get {
+      if !isKnownUniquelyReferenced(&impl) {
+        impl = Impl(copying: impl)
+      }
+      return impl
+    }
+  }
+  
+  var method: Method {
+    get { return impl.method }
+    set { implForMutation.method = newValue }
+  }
+  
+  var path: String {
+    get { return impl.path }
+    set { implForMutation.path = newValue }
+  }
+  
+  var headers: [String: String] {
+    get { return impl.headers }
+    set { implForMutation.headers = newValue }
+  }
+  
+  var body: Bytes {
+    get { return impl.body }
+    set { implForMutation.body = newValue }
+  }
+  
+  init(_ method: Method, path: String, headers: [String: String], body: Bytes) {
+    impl = Impl(method, path: path, headers: headers, body: body)
+  }
+}
+
+struct HybridResponse {
+    let status: Status
+    init(_ status: Status) {
+        self.status = status
+    }
+}
+
+typealias HybridResponder = (inout HybridRequest) -> HybridResponse
+
+protocol HybridMiddleware {
+    func respond(to request: inout HybridRequest, next: HybridResponder) -> HybridResponse
+}
+
+final class AppendPathHybridMiddleware: HybridMiddleware {
+    func respond(to request: inout HybridRequest, next: HybridResponder) -> HybridResponse {
+        request.path = request.path + "a"
+        return next(&request)
+    }
+}
+
+

--- a/Sources/request_types.swift
+++ b/Sources/request_types.swift
@@ -48,6 +48,23 @@ struct ValueResponse {
 
 
 
+typealias NonInoutValueResponder = (ValueRequest) -> ValueResponse
+
+protocol NonInoutValueMiddleware {
+    func respond(to request: ValueRequest, next: NonInoutValueResponder) -> ValueResponse
+}
+
+struct AppendPathNonInoutValueMiddleware: NonInoutValueMiddleware {
+    func respond(to request: ValueRequest, next: NonInoutValueResponder) -> ValueResponse {
+      var copy = request
+        copy.path = copy.path + "a"
+        return next(copy)
+    }
+}
+
+
+
+
 
 typealias ReferenceResponder = (ReferenceRequest) -> ReferenceResponse
 
@@ -157,6 +174,22 @@ final class AppendPathHybridMiddleware: HybridMiddleware {
     func respond(to request: inout HybridRequest, next: HybridResponder) -> HybridResponse {
         request.path = request.path + "a"
         return next(&request)
+    }
+}
+
+
+
+typealias NonInoutHybridResponder = (HybridRequest) -> HybridResponse
+
+protocol NonInoutHybridMiddleware {
+    func respond(to request: HybridRequest, next: NonInoutHybridResponder) -> HybridResponse
+}
+
+struct AppendPathNonInoutHybridMiddleware: NonInoutHybridMiddleware {
+    func respond(to request: HybridRequest, next: NonInoutHybridResponder) -> HybridResponse {
+      var copy = request
+        copy.path = copy.path + "a"
+        return next(copy)
     }
 }
 


### PR DESCRIPTION
This PR adds two additional sorts of designs to assess:

* A `HybridRequest` is a struct with a private nested class. The class contains the actual data, and the struct applies copy-on-write semantics to it. The idea is that the class can get arbitrarily large, but the struct will still only contain a pointer, so it will remain small and easy to pass. You only end up paying the expense of copying when a middleware actually mutates the request, and even then only when something else has already saved the request off somewhere. There's also `HybridResponder`, `HybridMiddleware`, etc. to handle these.
* `ValueNonInoutResponder` and `HybridNonInoutResponder` (and related types like middlewares, etc.) do not pass their requests `inout`—they pass them by value. I don't expect these designs to be blazing fast, but I'd like to have them in here for comparison purposes.

`HybridRequest` with `inout` has performance characteristics in between `ValueRequest` and `ReferenceRequest`. I'm hoping that means that, in cases where reference-based designs would be faster, hybrid designs will *still* be between value and reference, because value and hybrid have the same semantics, so we can switch between them without breaking anybody's code.

`ValueRequest` without `inout` is a little slower than `ReferenceRequest`, and `HybridRequest` without `inout` is much slower than either of them. That was definitely a surprise to me—I suspect that the Swift optimizer doesn't realize that `AppendPathNonInoutHybridMiddleware.respond(to:next:)` doesn't ever use `request` once it's been copied to `copy`, so it can destroy `request`, releasing `request.impl` and making `copy.impl` a unique reference to that instance.

| Design | Average | Standard Deviation |
|--------|---------|--------------------|
| Value	| 0.225	| 1.437% |
| Hybrid	| 0.232	| 0.607% |
| Reference	| 0.251	| 0.938% |
| NonInoutValue	| 0.31	| 0.695% |
| NonInoutHybrid	| 0.537	| 1.947% |